### PR TITLE
Add -utf8 output option

### DIFF
--- a/Demo/Source/main.m
+++ b/Demo/Source/main.m
@@ -135,6 +135,10 @@ int main (int argc, const char *argv[])
             {
                 outputStringEncoding = NSUTF16BigEndianStringEncoding;
             }
+            else if (!strcmp("-utf8", argv[i]))
+            {
+                outputStringEncoding = NSUTF8StringEncoding;
+            }
             else if (!strcmp("-macRoman", argv[i]))
             {
                 inputStringEncoding = NSMacOSRomanStringEncoding;
@@ -231,6 +235,7 @@ void showUsage(void)
     printf("    -q                       turns off multiple key/value pairs warning.\n");
     printf("    -bigEndian               output generated with big endian byte order.\n");
     printf("    -littleEndian            output generated with little endian byte order.\n");
+    printf("    -utf8                    output generated as UTF-8 not UTF-16.\n");
     printf("    -o dir                   place output files in 'dir'.\n\n");
     printf("    -defaultTable tablename  use 'tablename' instead of 'Localizable' as default table name.\n");
     printf("    Please see the genstrings2(1) man page for full documentation\n");


### PR DESCRIPTION
I had written a [blog post](http://gigliwood.com/blog/to-hell-with-utf-16-strings.html) about how troublesome it is to handle UTF-16 .strings files in my source tree.  I've decided to store my strings files as UTF-8 to eliminate confusion with endian issues, and also so that these files can actually be diff'd in GitHub rather than appearing as binary blobs.

The final remaining step has been to somehow override genstrings' propensity to output in UTF-16.  That means that I'd have to follow up with a conversion to UTF-8 so that my generated strings files (which I store in my source tree) don't get changed into UTF-16.

I've added UTF-8 output as an option to the demo "genstrings2" here, to make that step easier. Maybe others will find it useful as well. Yes, this extends the abilities of genstrings. Hopefully that is OK.
