### PR TITLE
Handle concatenated quoted strings properly

### DIFF
--- a/Core/Source/DTLocalizableStringScanner.m
+++ b/Core/Source/DTLocalizableStringScanner.m
@@ -288,7 +288,13 @@
         }
         else if (character == '"') 
         {
-            quotedString = [self _scanQuotedString];
+            if (quotedString) {
+              quotedString = [[quotedString substringToIndex:quotedString.length-1]
+                              stringByAppendingString:[[self _scanQuotedString] substringFromIndex:1]];
+            }
+            else {
+              quotedString = [self _scanQuotedString];
+            }
         }
         else 
         {
@@ -296,7 +302,7 @@
         }
     }
     
-    if (quotedString) 
+    if (quotedString)
     {
         return quotedString;
     }


### PR DESCRIPTION
Right now, for string literals split across multiple parts, e.g. the test case:

NSLocalizedString(@"test", @"foo " 
                                            "bar");

genstrings2 will give "bar" for the description.  genstrings will properly give "foo bar".  This patch fixes it so that genstrings2 and genstrings will be on parity with each other.
